### PR TITLE
Changed to one-off tickets instead of handing out the event key

### DIFF
--- a/contracts/PortMayor.sol
+++ b/contracts/PortMayor.sol
@@ -9,42 +9,54 @@ import './PortCoin.sol';
 
 contract PortMayor is Ownable, HasNoEther, CanReclaimToken {
 
-  PortCoin coin = PortCoin(0x0);
+  PortCoin coin;
   mapping(address => bool) active;
   mapping(address => mapping(address => bool)) seen;
+  mapping(address => mapping(bytes32 => bool)) ticketUsed;
 
-  event Attend(address attendee, address eventPublicKey);
-  event EventCreated(address eventPublicKey);
-  event EventEnded(address eventPublicKey);
+  event Attend(address attendee, address eventAddress);
+  event EventCreated(address eventAddress);
+  event EventEnded(address eventAddress);
+
+  function PortMayor(address portCoinAddress) public {
+    coin = PortCoin(portCoinAddress);
+  }
+
+  function isEventActive(address eventAddress) view public returns (bool){
+    return active[eventAddress];
+  }
+
+  function isTicketUsed(address eventAddress, bytes32 ticket) view public returns (bool){
+    return ticketUsed[eventAddress][ticket];
+  }
+
+  function attended(address eventAddress, address who) view public returns (bool){
+    return seen[eventAddress][who];
+  }
 
   function electNewMayor(address newMayor) onlyOwner public {
     coin.electNewMayor(newMayor);
   }
 
-  function createEvent(address publicKey) onlyOwner public {
-    active[publicKey] = true;
-    EventCreated(publicKey);
+  function createEvent(address eventAddress) onlyOwner public {
+    active[eventAddress] = true;
+    EventCreated(eventAddress);
   }
 
-  function isEventActive(address publicKey) view public returns (bool) {
-    return active[publicKey];
+  function endEvent(address eventAddress) onlyOwner public {
+    active[eventAddress] = false;
+    EventEnded(eventAddress);
   }
 
-  function endEvent(address publicKey) onlyOwner public {
-    active[publicKey] = false;
-    EventEnded(publicKey);
-  }
-
-  function attended(address publicKey, address who) view public returns (bool){
-    return seen[publicKey][who];
-  }
-
-  function attend(bytes signature, address publicKey) public {
-    require(active[publicKey]);
-    require(!seen[publicKey][msg.sender]);
-    require(ECRecovery.recover(keccak256(msg.sender), signature) == publicKey);
-    seen[publicKey][msg.sender] = true;
+  function attend(bytes32 ticket, bytes signature) public {
+    address eventAddress = ECRecovery.recover(ticket,signature);
+    require(active[eventAddress]);
+    require(!ticketUsed[eventAddress][ticket]);
+    require(!seen[eventAddress][msg.sender]);
+    seen[eventAddress][msg.sender] = true;
+    ticketUsed[eventAddress][ticket]=true;
     coin.issue(msg.sender, 1);
-    Attend(msg.sender, publicKey);
+    Attend(msg.sender, eventAddress);
   }
+
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,8 +3,8 @@ var PortMayor = artifacts.require('./PortMayor.sol');
 var ECRecovery = artifacts.require('zeppelin-solidity/contracts/ECRecovery.sol');
 
 module.exports = function(deployer) {
-  deployer.deploy(PortCoin);
-  deployer.deploy(ECRecovery);
-  deployer.link(ECRecovery, PortMayor);
-  deployer.deploy(PortMayor);
+    deployer.deploy(PortCoin)
+        .then(() => deployer.deploy(ECRecovery))
+        .then(() => deployer.link(ECRecovery, PortMayor))
+        .then(() => deployer.deploy(PortMayor, PortCoin.address));
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "ISC",
   "scripts": {
-    "test": "./scripts/test.sh"
+    "test": "./scripts/test.sh",
+    "create-tickets": "node ./scripts/createTickets"
   },
   "dependencies": {
     "argv": "^0.0.2",
@@ -17,6 +18,7 @@
     "expect": "^21.2.1",
     "truffle-contract": "^3.0.0",
     "truffle-wallet-provider": "^0.0.5",
+    "uuid": "^3.1.0",
     "web3": "^1.0.0-beta.26",
     "zeppelin-solidity": "^1.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "test": "./scripts/test.sh"
   },
   "dependencies": {
-    "argv": "0.0.2",
+    "argv": "^0.0.2",
     "ethereumjs-wallet": "^0.6.0",
     "expect": "^21.2.1",
     "truffle-contract": "^3.0.0",
-    "truffle-wallet-provider": "0.0.5",
+    "truffle-wallet-provider": "^0.0.5",
     "web3": "^1.0.0-beta.26",
     "zeppelin-solidity": "^1.4.0"
   }

--- a/scripts/createTickets.js
+++ b/scripts/createTickets.js
@@ -1,0 +1,22 @@
+/*jshint node: true,mocha:true */
+"use strict";
+
+var argv = require('argv');
+const Web3 = require('web3');
+const web3 = new Web3();
+
+var args = argv.run();
+if (args.targets.length < 2) {
+    console.log("Not enough arguments. Requires number of tickets and event private key.");
+    return;
+}
+
+
+for (var ticketNum = 0; ticketNum < args.targets[0]; ticketNum++) {
+    var ticket = "" + ticketNum;
+    console.log("Ticket: " + web3.utils.sha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket));
+    console.log("Signature: " + web3.eth.accounts.sign(ticket, args.targets[1]).signature);
+    if (ticketNum !== args.targets[0]-1) {
+        console.log("\n----------------------------------------------------------------------------------------------\n");
+    }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ output=$(nc -z localhost 8547; echo $?)
 if [ ! $trpc_running ]; then
   echo "Starting our own testrpc node instance"
   # we give each account 1M ether, needed for high-value tests
-  ganashe-cli \
+  ganache-cli \
     --port 8547 \
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200,1000000000000000000000000"  \
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201,1000000000000000000000000"  \

--- a/test/PortCoin.test.js
+++ b/test/PortCoin.test.js
@@ -44,7 +44,6 @@ contract('PortCoin', function(accounts) {
             .then(result => expect(result).toBe(true))
             .then(() => mayor.endEvent(eventAddress.getAddressString()))
             .then(result => {
-                console.log(JSON.stringify(result, null, "    "));
                 expect(result.logs[0].event).toBe('EventEnded');
                 expect(result.logs[0].args.eventAddress).toBe(eventAddress.getAddressString());
             })
@@ -53,9 +52,7 @@ contract('PortCoin', function(accounts) {
     });
 
     it('should issue coins and not allow the same ticket multiple times', () => {
-        //console.log(mayor)
         let eventAddress = wallet.generate();
-        console.log("ADDRESS: " + eventAddress.getAddressString());
         return mayor.createEvent(eventAddress.getAddressString())
             .then(() => {
                 var ticket = "1";
@@ -76,10 +73,8 @@ contract('PortCoin', function(accounts) {
             .catch((err) => expect(err.message).toBe("VM Exception while processing transaction: revert"));
     });
 
-    it('should ', () => {
-        //console.log(mayor)
+    it('shouldn\'t allow ticket use after event is closed', () => {
         let eventAddress = wallet.generate();
-        console.log("ADDRESS: " + eventAddress.getAddressString());
         return mayor.createEvent(eventAddress.getAddressString())
             .then(() => {
                 var ticket = "1";
@@ -91,8 +86,9 @@ contract('PortCoin', function(accounts) {
             .then((response) => {
                 expect(JSON.stringify(response)).toBe("\"1\"");
             })
+            .then(() => mayor.endEvent(eventAddress.getAddressString()))
             .then(() => {
-                var ticket = "1";
+                var ticket = "2";
                 var signature = web3.eth.accounts.sign(ticket, eventAddress.getPrivateKeyString());
                 var message = web3.utils.sha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket);
                 return mayor.attend(message, signature.signature, { from: accounts[1] });

--- a/test/PortCoin.test.js
+++ b/test/PortCoin.test.js
@@ -1,69 +1,103 @@
+/*jshint node: true,mocha:true */
+/*globals artifacts,contract*/
+"use strict";
 const expect = require('expect');
 const wallet = require('ethereumjs-wallet');
 const Web3 = require('web3');
 const web3 = new Web3();
 var PortCoin = artifacts.require("./PortCoin.sol");
 var PortMayor = artifacts.require('./PortMayor.sol');
-
+var ECRecovery = artifacts.require('zeppelin-solidity/contracts/ECRecovery.sol');
 contract('PortCoin', function(accounts) {
-  var portcoin;
-  var mayor;
+    var portcoin;
+    var mayor;
+    var ecRecover;
 
-  before(() => {
-    return PortCoin.deployed()
-      .then(instance => {
-        portcoin = instance;
-      })
-      .then(()=>PortMayor.deployed())
-      .then(instance => {
-        mayor = instance;
-        portcoin.electNewMayor(mayor.address);
-      })
-  })
+    beforeEach(() => {
+        return PortCoin.new()
+            .then((instance) => portcoin = instance)
+            .then(() => ECRecovery.deployed())
+            .then((instance) => {
+                PortMayor.link(ECRecovery, instance.adress);
+            })
+            .then(() => PortMayor.new(portcoin.address))
+            .then((instance) => {
+                mayor = instance;
+                portcoin.electNewMayor(mayor.address);
+            });
+    });
 
-  it('should deploy', () => {
-    return portcoin.symbol()
-      .then(symbol => expect(symbol).toBe('PORT'))
-  })
+    it('should deploy', () => {
+        return portcoin.symbol().then(symbol => expect(symbol).toBe('PORT'));
+    });
 
-  it('should create event', () => {
-    var address = wallet.generate();
-    console.log("ADDRESS: " + address.getAddressString());
-    return Promise.resolve()
-    .then(()=>mayor.isEventActive(address.getAddressString()))
-    .then(result=>expect(result).toBe(false))
-    .then(()=>mayor.createEvent(address.getAddressString()))
-    .then(result => {
-      expect(result.logs[0].event).toBe('EventCreated');
-      expect(result.logs[0].args.eventPublicKey).toBe(address.getAddressString());
-    })
-    .then(()=>mayor.isEventActive(address.getAddressString()))
-    .then(result=>expect(result).toBe(true))
-    .then(()=>mayor.endEvent(address.getAddressString()))
-    .then(result => {
-      console.log(JSON.stringify(result, null, "    "));
-      // expect(result.logs[0].event).toBe('EventEnded');
-      // expect(result.logs[0].args.eventPublicKey).toBe(address.getAddressString());
-    })
-    .then(()=>mayor.isEventActive(address.getAddressString()))
-    .then(result=>expect(result).toBe(false))
-  })
+    it('should create and end event', () => {
+        let eventAddress = wallet.generate();
+        return Promise.resolve().then(() => mayor.isEventActive(eventAddress.getAddressString()))
+            .then(result => expect(result).toBe(false))
+            .then(() => mayor.createEvent(eventAddress.getAddressString()))
+            .then(result => {
+                expect(result.logs[0].event).toBe('EventCreated');
+                expect(result.logs[0].args.eventAddress).toBe(eventAddress.getAddressString());
+            })
+            .then(() => mayor.isEventActive(eventAddress.getAddressString()))
+            .then(result => expect(result).toBe(true))
+            .then(() => mayor.endEvent(eventAddress.getAddressString()))
+            .then(result => {
+                console.log(JSON.stringify(result, null, "    "));
+                expect(result.logs[0].event).toBe('EventEnded');
+                expect(result.logs[0].args.eventAddress).toBe(eventAddress.getAddressString());
+            })
+            .then(() => mayor.isEventActive(eventAddress.getAddressString()))
+            .then(result => expect(result).toBe(false));
+    });
 
-  it('should issue coins', () => {
-    var address = wallet.generate();
-    console.log("ADDRESS: " + address.getAddressString());
-    return mayor.createEvent(address.getAddressString())
-    .then(()=>{
-      console.log("ACCT: " + accounts[1])
-      var signature = web3.eth.accounts.sign("Hello there", address.getPrivateKeyString())
-      console.log("SIG: " + signature);
-      return mayor.attend(accounts[1], signature);
-    })
-    .then(()=>mayor.endEvent(address.getAddressString()))
-    .then(result => {
-      expect(result.logs[0].event).toBe('EventEnded');
-      expect(result.logs[0].args.eventPublicKey).toBe(address.getAddressString());
-    })
-  })
+    it('should issue coins and not allow the same ticket multiple times', () => {
+        //console.log(mayor)
+        let eventAddress = wallet.generate();
+        console.log("ADDRESS: " + eventAddress.getAddressString());
+        return mayor.createEvent(eventAddress.getAddressString())
+            .then(() => {
+                var ticket = "1";
+                var signature = web3.eth.accounts.sign(ticket, eventAddress.getPrivateKeyString());
+                var message = web3.utils.soliditySha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket);
+                return mayor.attend(message, signature.signature);
+            })
+            .then(() => portcoin.balanceOf(accounts[0]))
+            .then((response) => {
+                expect(JSON.stringify(response)).toBe("\"1\"");
+            })
+            .then(() => {
+                var ticket = "1";
+                var signature = web3.eth.accounts.sign(ticket, eventAddress.getPrivateKeyString());
+                var message = web3.utils.sha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket);
+                return mayor.attend(message, signature.signature, { from: accounts[1] });
+            })
+            .catch((err) => expect(err.message).toBe("VM Exception while processing transaction: revert"));
+    });
+
+    it('should ', () => {
+        //console.log(mayor)
+        let eventAddress = wallet.generate();
+        console.log("ADDRESS: " + eventAddress.getAddressString());
+        return mayor.createEvent(eventAddress.getAddressString())
+            .then(() => {
+                var ticket = "1";
+                var signature = web3.eth.accounts.sign(ticket, eventAddress.getPrivateKeyString());
+                var message = web3.utils.soliditySha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket);
+                return mayor.attend(message, signature.signature);
+            })
+            .then(() => portcoin.balanceOf(accounts[0]))
+            .then((response) => {
+                expect(JSON.stringify(response)).toBe("\"1\"");
+            })
+            .then(() => {
+                var ticket = "1";
+                var signature = web3.eth.accounts.sign(ticket, eventAddress.getPrivateKeyString());
+                var message = web3.utils.sha3("\x19Ethereum Signed Message:\n" + ticket.length + ticket);
+                return mayor.attend(message, signature.signature, { from: accounts[1] });
+            })
+            .catch((err) => expect(err.message).toBe("VM Exception while processing transaction: revert"));
+    });
 
 });

--- a/truffle.js
+++ b/truffle.js
@@ -22,7 +22,7 @@ networks = {
   }
 }
 
-var key = fs.readFileSync('/Users/pete/.demo.private.key', 'utf8');
+var key = fs.readFileSync('/home/nate/test.key', 'utf8');
 var wallet = Wallet.fromPrivateKey(Buffer.from(key.substring(2), 'hex'));
 var nodes = {
   'mainnet': 'https://mainnet.infura.io/bOyWfPGcs8jj2g9UXNYr',


### PR DESCRIPTION
With the method of handing out the private key, we risk people sending transactions from as many wallets as they want and then accumulating the gained PORT tokens. With the one-off tickets, you sign 50 unique "tickets"  with the events private key, and hand the tickets out to the attendees. The tickets are only good until the event is ended.

A ticket is made up of two things: the hash of the message (actually `keccak256("\x19Ethereum Signed Message:\n" + ticket.length + ticket)`) and the signature of that hash. The user calls the `attend(bytes32 ticket, bytes signature` function of PortMayor contract to claim attendance. ECRecover is done on the ticket/signature, and if the recovered address is an active event **and ** the tx sender hasn't "attended" the event already **and** the hashed ticket hasn't been used for that event before, then the sending address gets 1 PORT token. 